### PR TITLE
GDB-10175 Added cashing of the BlankNodeIdGenerator. Once created it …

### DIFF
--- a/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
@@ -16,11 +16,13 @@
 package com.apicatalog.jsonld;
 
 import java.net.URI;
+import java.util.Set;
 
 import com.apicatalog.jsonld.context.cache.Cache;
 import com.apicatalog.jsonld.context.cache.LruCache;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.document.JsonDocument;
+import com.apicatalog.jsonld.flattening.BlankNodeIdGenerator;
 import com.apicatalog.jsonld.json.JsonProvider;
 import com.apicatalog.jsonld.loader.DocumentLoader;
 import com.apicatalog.jsonld.loader.SchemeRouter;
@@ -121,6 +123,10 @@ public final class JsonLdOptions {
     private Cache<String, Document> documentCache;
 
     private boolean uriValidation;
+    
+    private BlankNodeIdGenerator generator;
+    
+    private Set<String> usedBlankNodeIds;
 
     public JsonLdOptions() {
         this(SchemeRouter.defaultInstance());
@@ -157,6 +163,7 @@ public final class JsonLdOptions {
         this.contextCache = new LruCache<>(256);
         this.documentCache = null;
         this.uriValidation = DEFAULT_URI_VALIDATION;
+        this.generator = new BlankNodeIdGenerator();
     }
 
     public JsonLdOptions(JsonLdOptions options) {
@@ -188,6 +195,8 @@ public final class JsonLdOptions {
         this.contextCache = options.contextCache;
         this.documentCache = options.documentCache;
         this.uriValidation = options.uriValidation;
+        this.generator = options.generator;
+        this.usedBlankNodeIds = options.usedBlankNodeIds;
     }
 
     /**
@@ -485,5 +494,22 @@ public final class JsonLdOptions {
      */
     public void setUriValidation(boolean enabled) {
         this.uriValidation = enabled;
+    }
+    
+    public BlankNodeIdGenerator getGenerator() {
+        return generator;
+    }
+    
+    public void setGenerator(BlankNodeIdGenerator generator) {
+        this.generator = generator;
+    }
+    
+    public Set<String> getUsedBlankNodeIds() {
+        return usedBlankNodeIds;
+    }
+    
+    // This set is provided externally in GraphDB, when NDJSONLD export is selected
+    public void setUsedBlankNodeIds(Set<String> usedBlankNodeIds) {
+        this.usedBlankNodeIds = usedBlankNodeIds;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/flattening/Flattening.java
+++ b/src/main/java/com/apicatalog/jsonld/flattening/Flattening.java
@@ -15,10 +15,13 @@
  */
 package com.apicatalog.jsonld.flattening;
 
+import static com.apicatalog.jsonld.flattening.NodeMapBuilder.getNodeMap;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.json.JsonProvider;
 import com.apicatalog.jsonld.json.JsonUtils;
 import com.apicatalog.jsonld.lang.Keywords;
@@ -53,13 +56,10 @@ public final class Flattening {
         return this;
     }
 
-    public JsonArray flatten() throws JsonLdError {
+    public JsonArray flatten(final JsonLdOptions options) throws JsonLdError {
 
         // 1.
-        final NodeMap nodeMap = new NodeMap();
-
-        // 2.
-        NodeMapBuilder.with(element, nodeMap).build();
+        final NodeMap nodeMap = getNodeMap(element, options);
 
         // 3.
         final Map<String, Map<String, JsonValue>> defaultGraph = nodeMap.get(Keywords.DEFAULT).orElseThrow(IllegalStateException::new);

--- a/src/main/java/com/apicatalog/jsonld/flattening/NodeMap.java
+++ b/src/main/java/com/apicatalog/jsonld/flattening/NodeMap.java
@@ -33,11 +33,16 @@ public final class NodeMap {
 
     private final Map<String, Map<String, Map<String, JsonValue>>> index;
 
-    private final BlankNodeIdGenerator generator = new BlankNodeIdGenerator();
-
+    private final BlankNodeIdGenerator generator;
+    
     public NodeMap() {
+        this(new BlankNodeIdGenerator());
+    }
+
+    public NodeMap(BlankNodeIdGenerator generator) {
         this.index = new LinkedHashMap<>();
         this.index.put(Keywords.DEFAULT, new LinkedHashMap<>());
+        this.generator = generator;
     }
 
     public void set(String graphName, String subject, String property, JsonValue value) {

--- a/src/main/java/com/apicatalog/jsonld/flattening/NodeMapBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/flattening/NodeMapBuilder.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import com.apicatalog.jsonld.JsonLdError;
 import com.apicatalog.jsonld.JsonLdErrorCode;
+import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.json.JsonProvider;
 import com.apicatalog.jsonld.json.JsonUtils;
 import com.apicatalog.jsonld.lang.BlankNode;
@@ -92,6 +93,24 @@ public final class NodeMapBuilder {
     public NodeMapBuilder referencedNode(Map<String, JsonValue> referencedNode) {
         this.referencedNode = referencedNode;
         return this;
+    }
+    
+    /**
+     * Generates a NodeMap for the provided JSON-LD structure and options.
+     * This method is particularly useful for NDJSONLD format, as it keeps track of created blank node ids between sequential invocations.
+     * Additionally, it allows the context to be retained between different batch processing operations.
+     * @param element The JSON structure for which the NodeMap is generated.
+     * @param options The JsonLdOptions options to configure the NodeMap generation. Can be null.
+     * @return The generated NodeMap.
+     * @throws JsonLdError If an error occurs during the generation of the NodeMap.
+     */
+    public static NodeMap getNodeMap(JsonStructure element, JsonLdOptions options) throws JsonLdError {
+        NodeMap nodeMap = with(element, options != null && options.getGenerator() != null ? new NodeMap(options.getGenerator()) : new NodeMap()).build();
+        
+        if (options != null) {
+            options.setGenerator(options.getGenerator());
+        }
+        return nodeMap;
     }
 
     public NodeMap build() throws JsonLdError {

--- a/src/main/java/com/apicatalog/jsonld/processor/FlatteningProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/FlatteningProcessor.java
@@ -99,7 +99,7 @@ public final class FlatteningProcessor {
 
         // 5.
         // 6.
-        JsonStructure flattenedOutput = Flattening.with(expandedInput).ordered(options.isOrdered()).flatten();
+        JsonStructure flattenedOutput = Flattening.with(expandedInput).ordered(options.isOrdered()).flatten(options);
 
         // 6.1.
         if (context != null) {

--- a/src/main/java/com/apicatalog/jsonld/processor/ToRdfProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/ToRdfProcessor.java
@@ -15,6 +15,8 @@
  */
 package com.apicatalog.jsonld.processor;
 
+import static com.apicatalog.jsonld.flattening.NodeMapBuilder.getNodeMap;
+
 import java.net.URI;
 
 import com.apicatalog.jsonld.JsonLdError;
@@ -22,8 +24,6 @@ import com.apicatalog.jsonld.JsonLdErrorCode;
 import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.deseralization.JsonLdToRdf;
 import com.apicatalog.jsonld.document.Document;
-import com.apicatalog.jsonld.flattening.NodeMap;
-import com.apicatalog.jsonld.flattening.NodeMapBuilder;
 import com.apicatalog.jsonld.loader.DocumentLoaderOptions;
 import com.apicatalog.rdf.Rdf;
 import com.apicatalog.rdf.RdfDataset;
@@ -70,7 +70,7 @@ public final class ToRdfProcessor {
 
         return JsonLdToRdf
                         .with(
-                            NodeMapBuilder.with(expandedInput, new NodeMap()).build(),
+                            getNodeMap(expandedInput, options),
                             Rdf.createDataset()
                             )
                         .produceGeneralizedRdf(options.isProduceGeneralizedRdf())


### PR DESCRIPTION
…is cached into JsonLdOptions.

Also added cashing of the blank node ids that are referenced into externally provided structure. This allows to not remove referred blank nodes during framing.